### PR TITLE
Add structure for recurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var cal = ICalendar()
 
 cal.events.append(ICalendarEvent(
     description: "My awesome event",
-    dtstart: ICalendarDate(date: Date()),
+    dtstart: .dateTime(Date()),
     duration: ICalendarDuration(hours: 1)
 ))
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ var cal = ICalendar()
 cal.events.append(ICalendarEvent(
     description: "My awesome event",
     dtstart: .dateTime(Date()),
-    duration: ICalendarDuration(hours: 1)
+    duration: .hours(1),
+    rrule: .init(
+        frequency: .weekly,
+        byDay: [.every(.tuesday), .every(.saturday)]
+    )
 ))
 
 print(cal.iCalendarEncoded)
@@ -29,13 +33,14 @@ print(cal.iCalendarEncoded)
 // PRODID:-//swift-icalendar//swift-icalendar//EN
 // CALSCALE:GREGORIAN
 // BEGIN:VEVENT
-// DTSTAMP:20201016T194809Z
-// UID:B22CF435-BE06-4EE9-B7B0-6EE6878E3A06
-// CREATED:20201016T194809Z
+// DTSTAMP:20201017T000135Z
+// UID:327278D1-F140-49C9-AB75-C1D9579C1851
+// CREATED:20201017T000135Z
 // DESCRIPTION:My awesome event
-// DTSTART:20201016T194809Z
-// LAST-MODIFIED:20201016T194809Z
+// DTSTART:20201017T000135Z
+// LAST-MODIFIED:20201017T000135Z
 // DURATION:P0DT1H0M0S
+// RRULE:FREQ=WEEKLY;BYDAY=TU,SA
 // END:VEVENT
 // END:VCALENDAR
 ```

--- a/Sources/ICalendar/components/ICalendarEvent.swift
+++ b/Sources/ICalendar/components/ICalendarEvent.swift
@@ -97,20 +97,6 @@ public struct ICalendarEvent: ICalendarComponent {
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.6
     public var url: URL?
-    /// This property is used in conjunction with the "UID" and
-    /// "SEQUENCE" properties to identify a specific instance of a
-    /// recurring "VEVENT", "VTODO", or "VJOURNAL" calendar component.
-    /// The property value is the original value of the "DTSTART" property
-    /// of the recurrence instance.
-    ///
-    /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.4
-    public var recurrenceId: Date?
-    /// This property defines a rule or repeating pattern for
-    /// recurring events, to-dos, journal entries, or time zone
-    /// definitions.
-    ///
-    /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
-    public var rrule: ICalendarRecurrenceRule?
 
     // Mutually exclusive specifications of end date
 
@@ -132,6 +118,21 @@ public struct ICalendarEvent: ICalendarComponent {
     public var duration: ICalendarDuration? {
         willSet { dtend = nil }
     }
+
+    /// This property is used in conjunction with the "UID" and
+    /// "SEQUENCE" properties to identify a specific instance of a
+    /// recurring "VEVENT", "VTODO", or "VJOURNAL" calendar component.
+    /// The property value is the original value of the "DTSTART" property
+    /// of the recurrence instance.
+    ///
+    /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.4
+    public var recurrenceId: Date?
+    /// This property defines a rule or repeating pattern for
+    /// recurring events, to-dos, journal entries, or time zone
+    /// definitions.
+    ///
+    /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
+    public var rrule: ICalendarRecurrenceRule?
 
     // TODO: Define properties that can be specified multiple times:
     // public var attachments
@@ -165,10 +166,10 @@ public struct ICalendarEvent: ICalendarComponent {
             .line("SUMMARY", summary),
             .line("TRANSP", transp),
             .line("URL", url),
-            .line("RECURRENCE-ID", recurrenceId),
-            .line("RRULE", rrule),
             .line("DTEND", dtend),
-            .line("DURATION", duration)
+            .line("DURATION", duration),
+            .line("RECURRENCE-ID", recurrenceId),
+            .line("RRULE", rrule)
         ]
     }
 
@@ -189,10 +190,10 @@ public struct ICalendarEvent: ICalendarComponent {
         summary: String? = nil,
         transp: String? = nil,
         url: URL? = nil,
-        recurrenceId: Date? = nil,
-        rrule: ICalendarRecurrenceRule? = nil,
         dtend: ICalendarDate? = nil,
         duration: ICalendarDuration? = nil,
+        recurrenceId: Date? = nil,
+        rrule: ICalendarRecurrenceRule? = nil,
         alarms: [ICalendarAlarm] = []
     ) {
         self.dtstamp = dtstamp

--- a/Sources/ICalendar/components/ICalendarEvent.swift
+++ b/Sources/ICalendar/components/ICalendarEvent.swift
@@ -211,5 +211,7 @@ public struct ICalendarEvent: ICalendarComponent {
         self.dtend = dtend
         self.duration = duration
         self.alarms = alarms
+
+        assert(dtend == nil || duration == nil, "End date/time and duration must not be specified together!")
     }
 }

--- a/Sources/ICalendar/components/ICalendarEvent.swift
+++ b/Sources/ICalendar/components/ICalendarEvent.swift
@@ -110,7 +110,7 @@ public struct ICalendarEvent: ICalendarComponent {
     /// definitions.
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
-    public var rrule: String? // TODO: Add more structure
+    public var rrule: ICalendarRecurrenceRule?
 
     // Mutually exclusive specifications of end date
 
@@ -190,7 +190,7 @@ public struct ICalendarEvent: ICalendarComponent {
         transp: String? = nil,
         url: URL? = nil,
         recurrenceId: Date? = nil,
-        rrule: String? = nil,
+        rrule: ICalendarRecurrenceRule? = nil,
         dtend: ICalendarDate? = nil,
         duration: ICalendarDuration? = nil,
         alarms: [ICalendarAlarm] = []

--- a/Sources/ICalendar/components/ICalendarEvent.swift
+++ b/Sources/ICalendar/components/ICalendarEvent.swift
@@ -117,11 +117,16 @@ public struct ICalendarEvent: ICalendarComponent {
     /// This property specifies the date and time that a calendar
     /// component ends.
     ///
+    /// Must have the same 'ignoreTime'-value as tstart.
+    /// Mutually exclusive to 'due'.
+    ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.2
     public var dtend: ICalendarDate? {
         willSet { duration = nil }
     }
     /// This property specifies a positive duration of time.
+    ///
+    /// Mutually exclusive to 'due'.
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.5
     public var duration: ICalendarDuration? {

--- a/Sources/ICalendar/components/ICalendarToDo.swift
+++ b/Sources/ICalendar/components/ICalendarToDo.swift
@@ -123,11 +123,16 @@ public struct ICalendarToDo: ICalendarComponent {
     /// This property specifies the date and time that a calendar
     /// component ends.
     ///
+    /// Must have the same 'ignoreTime'-value as tstart.
+    /// Mutually exclusive to 'duration'.
+    ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.2
     public var due: ICalendarDate? {
         willSet { duration = nil }
     }
     /// This property specifies a positive duration of time.
+    ///
+    /// Mutually exclusive to 'due'.
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.5
     public var duration: ICalendarDuration? {

--- a/Sources/ICalendar/components/ICalendarToDo.swift
+++ b/Sources/ICalendar/components/ICalendarToDo.swift
@@ -103,20 +103,6 @@ public struct ICalendarToDo: ICalendarComponent {
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.6
     public var url: URL?
-    /// This property is used in conjunction with the "UID" and
-    /// "SEQUENCE" properties to identify a specific instance of a
-    /// recurring "VEVENT", "VTODO", or "VJOURNAL" calendar component.
-    /// The property value is the original value of the "DTSTART" property
-    /// of the recurrence instance.
-    ///
-    /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.4
-    public var recurrenceId: Date?
-    /// This property defines a rule or repeating pattern for
-    /// recurring events, to-dos, journal entries, or time zone
-    /// definitions.
-    ///
-    /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
-    public var rrule: ICalendarRecurrenceRule?
 
     // Mutually exclusive specifications of end date
 
@@ -138,6 +124,21 @@ public struct ICalendarToDo: ICalendarComponent {
     public var duration: ICalendarDuration? {
         willSet { due = nil }
     }
+
+    /// This property is used in conjunction with the "UID" and
+    /// "SEQUENCE" properties to identify a specific instance of a
+    /// recurring "VEVENT", "VTODO", or "VJOURNAL" calendar component.
+    /// The property value is the original value of the "DTSTART" property
+    /// of the recurrence instance.
+    ///
+    /// See https://tools.ietf.org/html/rfc5545#section-3.8.4.4
+    public var recurrenceId: Date?
+    /// This property defines a rule or repeating pattern for
+    /// recurring events, to-dos, journal entries, or time zone
+    /// definitions.
+    ///
+    /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
+    public var rrule: ICalendarRecurrenceRule?
 
     // TODO: Define properties that can be specified multiple times:
     // public var attachments
@@ -173,10 +174,10 @@ public struct ICalendarToDo: ICalendarComponent {
             .line("STATUS", status),
             .line("SUMMARY", summary),
             .line("URL", url),
-            .line("RECURRENCE-ID", recurrenceId),
-            .line("RRULE", rrule),
             .line("DUE", due),
-            .line("DURATION", duration)
+            .line("DURATION", duration),
+            .line("RECURRENCE-ID", recurrenceId),
+            .line("RRULE", rrule)
         ]
     }
 
@@ -199,10 +200,10 @@ public struct ICalendarToDo: ICalendarComponent {
         summary: String? = nil,
         transp: String? = nil,
         url: URL? = nil,
-        recurrenceId: Date? = nil,
-        rrule: ICalendarRecurrenceRule? = nil,
         due: ICalendarDate? = nil,
         duration: ICalendarDuration? = nil,
+        recurrenceId: Date? = nil,
+        rrule: ICalendarRecurrenceRule? = nil,
         alarms: [ICalendarAlarm] = []
     ) {
         self.dtstamp = dtstamp

--- a/Sources/ICalendar/components/ICalendarToDo.swift
+++ b/Sources/ICalendar/components/ICalendarToDo.swift
@@ -116,7 +116,7 @@ public struct ICalendarToDo: ICalendarComponent {
     /// definitions.
     ///
     /// See https://tools.ietf.org/html/rfc5545#section-3.8.5.3
-    public var rrule: String? // TODO: Add more structure
+    public var rrule: ICalendarRecurrenceRule?
 
     // Mutually exclusive specifications of end date
 
@@ -200,7 +200,7 @@ public struct ICalendarToDo: ICalendarComponent {
         transp: String? = nil,
         url: URL? = nil,
         recurrenceId: Date? = nil,
-        rrule: String? = nil,
+        rrule: ICalendarRecurrenceRule? = nil,
         due: ICalendarDate? = nil,
         duration: ICalendarDuration? = nil,
         alarms: [ICalendarAlarm] = []

--- a/Sources/ICalendar/components/ICalendarToDo.swift
+++ b/Sources/ICalendar/components/ICalendarToDo.swift
@@ -222,5 +222,7 @@ public struct ICalendarToDo: ICalendarComponent {
         self.due = due
         self.duration = duration
         self.alarms = alarms
+
+        assert(due == nil || duration == nil, "Due date/time and duration must not be specified together!")
     }
 }

--- a/Sources/ICalendar/structures/ICalendarDate.swift
+++ b/Sources/ICalendar/structures/ICalendarDate.swift
@@ -20,4 +20,12 @@ public struct ICalendarDate: ICalendarPropertyEncodable {
         self.date = date
         self.ignoreTime = ignoreTime
     }
+
+    public static func dateOnly(_ date: Date) -> ICalendarDate {
+        ICalendarDate(date: date, ignoreTime: true)
+    }
+
+    public static func dateTime(_ date: Date) -> ICalendarDate {
+        ICalendarDate(date: date, ignoreTime: false)
+    }
 }

--- a/Sources/ICalendar/structures/ICalendarDuration.swift
+++ b/Sources/ICalendar/structures/ICalendarDuration.swift
@@ -31,7 +31,7 @@ public struct ICalendarDuration: ICalendarPropertyEncodable, AdditiveArithmetic 
         var encodedDuration: String
         let (weeks, days, hours, minutes, seconds) = parts
 
-        if weeks > 0 {
+        if weeks != 0 {
             encodedDuration = "\(weeks)W"
         } else {
             encodedDuration = "\(days)DT\(hours)H\(minutes)M\(seconds)S"

--- a/Sources/ICalendar/structures/ICalendarDuration.swift
+++ b/Sources/ICalendar/structures/ICalendarDuration.swift
@@ -3,6 +3,8 @@
 /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.5
 public struct ICalendarDuration: ICalendarPropertyEncodable {
     public var sign: Bool
+
+    // TODO: Use simpler internal representation, e.g. just seconds
     
     public var weeks: Int? = nil
     public var days: Int? = nil
@@ -33,5 +35,25 @@ public struct ICalendarDuration: ICalendarPropertyEncodable {
         self.hours = hours
         self.minutes = minutes
         self.seconds = seconds
+    }
+
+    public static func weeks(_ weeks: Int) -> ICalendarDuration {
+        ICalendarDuration(weeks: weeks)
+    }
+
+    public static func days(_ days: Int) -> ICalendarDuration {
+        ICalendarDuration(days: days)
+    }
+
+    public static func hours(_ hours: Int) -> ICalendarDuration {
+        ICalendarDuration(hours: hours)
+    }
+
+    public static func minutes(_ minutes: Int) -> ICalendarDuration {
+        ICalendarDuration(minutes: minutes)
+    }
+    
+    public static func seconds(_ seconds: Int) -> ICalendarDuration {
+        ICalendarDuration(seconds: seconds)
     }
 }

--- a/Sources/ICalendar/structures/ICalendarDuration.swift
+++ b/Sources/ICalendar/structures/ICalendarDuration.swift
@@ -2,7 +2,7 @@
 ///
 /// See https://tools.ietf.org/html/rfc5545#section-3.8.2.5
 public struct ICalendarDuration: ICalendarPropertyEncodable {
-    public var negative: Bool
+    public var sign: Bool
     
     public var weeks: Int? = nil
     public var days: Int? = nil
@@ -19,16 +19,16 @@ public struct ICalendarDuration: ICalendarPropertyEncodable {
             encodedDuration = "\(days ?? 0)DT\(hours ?? 0)H\(minutes ?? 0)M\(seconds ?? 0)S"
         }
 
-        return "\(negative ? "-" : "")P\(encodedDuration)"
+        return "\(sign ? "" : "-")P\(encodedDuration)"
     }
 
-    public init(negative: Bool = false, weeks: Int) {
-        self.negative = negative
+    public init(sign: Bool = true, weeks: Int) {
+        self.sign = sign
         self.weeks = weeks
     }
 
-    public init(negative: Bool = false, days: Int = 0, hours: Int = 0, minutes: Int = 0, seconds: Int = 0) {
-        self.negative = negative
+    public init(sign: Bool = true, days: Int = 0, hours: Int = 0, minutes: Int = 0, seconds: Int = 0) {
+        self.sign = sign
         self.days = days
         self.hours = hours
         self.minutes = minutes

--- a/Sources/ICalendar/structures/ICalendarDuration.swift
+++ b/Sources/ICalendar/structures/ICalendarDuration.swift
@@ -31,7 +31,7 @@ public struct ICalendarDuration: ICalendarPropertyEncodable, AdditiveArithmetic 
         var encodedDuration: String
         let (weeks, days, hours, minutes, seconds) = parts
 
-        if weeks != 0 {
+        if totalSeconds % week == 0 {
             encodedDuration = "\(weeks)W"
         } else {
             encodedDuration = "\(days)DT\(hours)H\(minutes)M\(seconds)S"

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -35,29 +35,52 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         didSet { assert(byHours?.allSatisfy { (0..<24).contains($0) } ?? true, "by-hour rules must be between 0 and 24 (exclusive): \(byHours ?? [])") }
     }
     /// At which days (of the week/year) it should occur.
-    public var byDay: [SignedDay]?
+    public var byDays: [SignedDay]?
     /// At which days of the month it should occur.
     public var byDaysOfMonth: [SignedDayOfMonth]?
     /// At which days of the year it should occur.
     public var byDaysOfYear: [SignedDayOfYear]?
     /// At which weeks of the year it should occur.
-    public var byWeekOfYear: [SignedWeekOfYear]?
+    public var byWeeksOfYear: [SignedWeekOfYear]?
     /// At which months it should occur.
     /// Must be between 1 and 12 (inclusive).
-    public var byMonthOfYear: [Int]? {
-        didSet { assert(byMonthOfYear?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonthOfYear ?? [])") }
+    public var byMonths: [Int]? {
+        didSet { assert(byMonths?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonths ?? [])") }
+    }
+    /// Specifies a list of values
+    /// that corresponds to the nth occurrence within the set of
+    /// recurrence instances specified by the rule. By-set-pos operates on
+    /// a set of recurrence instances in one interval of the recurrence
+    /// rule.  For example, in a weekly rule, the interval would be one
+    /// week A set of recurrence instances starts at the beginning of the
+    /// interval defined by the frequency rule part.  Valid values are 1 to 366
+    /// or -366 to -1.  It MUST only be used in conjunction with another
+    /// by-xxx rule part.
+    public var bySetPos: [Int]? {
+        didSet { assert(bySetPos?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(bySetPos ?? [])") }
     }
     /// The day on which the workweek starts.
     /// Monday by default.
     public var startOfWorkweek: DayOfWeek?
 
-    private var properties: [String: ICalendarEncodable?] {
-        [
-            "FREQ": frequency,
-            "INTERVAL": interval,
-            "UNTIL": until,
-            "COUNT": count
+    private var properties: [(String, ICalendarEncodable?)] {
+        let groupedProperties: [(String, [ICalendarEncodable]?)] = [
+            ("FREQ", [frequency]),
+            ("INTERVAL", interval.map { [$0] } ?? []),
+            ("UNTIL", until.map { [$0] } ?? []),
+            ("COUNT", count.map { [$0] } ?? []),
+            ("BYSECOND", bySeconds),
+            ("BYMINUTE", byMinutes),
+            ("BYHOUR", byHours),
+            ("BYDAY", byDays),
+            ("BYMONTHDAY", byDaysOfMonth),
+            ("BYYEARDAY", byDaysOfYear),
+            ("BYWEEKNO", byWeeksOfYear),
+            ("BYMONTH", byMonths),
+            ("BYSETPOS", bySetPos),
+            ("WKST", startOfWorkweek.map { [$0] } ?? [])
         ]
+        return groupedProperties.flatMap { (key, values) in (values ?? []).map { (key, $0) } }
     }
 
     public var iCalendarEncoded: String {

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -21,41 +21,41 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
 
     /// At which seconds of the minute it should occur.
     /// Must be between 0 and 60 (inclusive).
-    public var bySeconds: [Int]? {
-        didSet { assert(bySeconds?.allSatisfy { (0...60).contains($0) } ?? true, "by-second rules must be between 0 and 60 (inclusive): \(bySeconds ?? [])") }
+    public var bySecond: [Int]? {
+        didSet { assert(bySecond?.allSatisfy { (0...60).contains($0) } ?? true, "by-second rules must be between 0 and 60 (inclusive): \(bySecond ?? [])") }
     }
     /// At which minutes of the hour it should occur.
     /// Must be between 0 and 60 (exclusive).
-    public var byMinutes: [Int]? {
-        didSet { assert(byMinutes?.allSatisfy { (0..<60).contains($0) } ?? true, "by-hour rules must be between 0 and 60 (exclusive): \(byMinutes ?? [])") }
+    public var byMinute: [Int]? {
+        didSet { assert(byMinute?.allSatisfy { (0..<60).contains($0) } ?? true, "by-hour rules must be between 0 and 60 (exclusive): \(byMinute ?? [])") }
     }
     /// At which hours of the day it should occur.
     /// Must be between 0 and 24 (exclusive).
-    public var byHours: [Int]? {
-        didSet { assert(byHours?.allSatisfy { (0..<24).contains($0) } ?? true, "by-hour rules must be between 0 and 24 (exclusive): \(byHours ?? [])") }
+    public var byHour: [Int]? {
+        didSet { assert(byHour?.allSatisfy { (0..<24).contains($0) } ?? true, "by-hour rules must be between 0 and 24 (exclusive): \(byHour ?? [])") }
     }
     /// At which days (of the week/year) it should occur.
-    public var byDays: [Day]?
+    public var byDay: [Day]?
     /// At which days of the month it should occur. Specifies a COMMA-separated
     /// list of days of the month. Valid values are 1 to 31 or -31 to -1.
-    public var byDaysOfMonth: [Int]? {
-        didSet { assert(byDaysOfYear?.allSatisfy { (1...31).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 31 or -31 and -1: \(byDaysOfMonth ?? [])") }
+    public var byDayOfMonth: [Int]? {
+        didSet { assert(byDaysOfYear?.allSatisfy { (1...31).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 31 or -31 and -1: \(byDayOfMonth ?? [])") }
     }
     /// At which days of the year it should occur. Specifies a list of days
     /// of the year.  Valid values are 1 to 366 or -366 to -1.
     public var byDaysOfYear: [Int]? {
-        didSet { assert(byWeeksOfYear?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(byDaysOfYear ?? [])") }
+        didSet { assert(byWeekOfYear?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(byDaysOfYear ?? [])") }
     }
     /// At which weeks of the year it should occur. Specificies a list of
     /// ordinals specifying weeks of the year. Valid values are 1 to 53 or -53 to
     /// -1.
-    public var byWeeksOfYear: [Int]? {
-        didSet { assert(byWeeksOfYear?.allSatisfy { (1...53).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 53 or -53 and -1: \(byWeeksOfYear ?? [])") }
+    public var byWeekOfYear: [Int]? {
+        didSet { assert(byWeekOfYear?.allSatisfy { (1...53).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 53 or -53 and -1: \(byWeekOfYear ?? [])") }
     }
     /// At which months it should occur.
     /// Must be between 1 and 12 (inclusive).
-    public var byMonths: [Int]? {
-        didSet { assert(byMonths?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonths ?? [])") }
+    public var byMonth: [Int]? {
+        didSet { assert(byMonth?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonth ?? [])") }
     }
     /// Specifies a list of values that corresponds to the nth occurrence within
     /// the set of recurrence instances specified by the rule. By-set-pos
@@ -72,28 +72,27 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
     /// Monday by default.
     public var startOfWorkweek: DayOfWeek?
 
-    private var properties: [(String, ICalendarEncodable?)] {
-        let groupedProperties: [(String, [ICalendarEncodable]?)] = [
+    private var properties: [(String, [ICalendarEncodable]?)] {
+        [
             ("FREQ", [frequency]),
-            ("INTERVAL", interval.map { [$0] } ?? []),
-            ("UNTIL", until.map { [$0] } ?? []),
-            ("COUNT", count.map { [$0] } ?? []),
-            ("BYSECOND", bySeconds),
-            ("BYMINUTE", byMinutes),
-            ("BYHOUR", byHours),
-            ("BYDAY", byDays),
-            ("BYMONTHDAY", byDaysOfMonth),
+            ("INTERVAL", interval.map { [$0] }),
+            ("UNTIL", until.map { [$0] }),
+            ("COUNT", count.map { [$0] }),
+            ("BYSECOND", bySecond),
+            ("BYMINUTE", byMinute),
+            ("BYHOUR", byHour),
+            ("BYDAY", byDay),
+            ("BYMONTHDAY", byDayOfMonth),
             ("BYYEARDAY", byDaysOfYear),
-            ("BYWEEKNO", byWeeksOfYear),
-            ("BYMONTH", byMonths),
+            ("BYWEEKNO", byWeekOfYear),
+            ("BYMONTH", byMonth),
             ("BYSETPOS", bySetPos),
-            ("WKST", startOfWorkweek.map { [$0] } ?? [])
+            ("WKST", startOfWorkweek.map { [$0] })
         ]
-        return groupedProperties.flatMap { (key, values) in (values ?? []).map { (key, $0) } }
     }
 
     public var iCalendarEncoded: String {
-        properties.compactMap { (key, value) in value.map { "\(key)=\($0.iCalendarEncoded)" } }.joined(separator: ";")
+        properties.compactMap { (key, values) in values.map { "\(key)=\($0.map(\.iCalendarEncoded).joined(separator: ","))" } }.joined(separator: ";")
     }
 
     public enum Frequency: String, ICalendarEncodable {
@@ -134,7 +133,39 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
 
             assert(weekOfYear.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(weekOfYear.map(String.init) ?? "?") is not between 1 and 53 or -53 and -1 (each inclusive)")
         }
+
+        public static func dayOfWeek(_ dayOfWeek: DayOfWeek) -> Self {
+            Self(dayOfWeek: dayOfWeek)
+        }
     }
 
-    // TODO: Initializer
+    public init(
+        frequency: Frequency,
+        interval: Int? = nil,
+        until: ICalendarDate? = nil,
+        count: Int? = nil,
+        bySecond: [Int]? = nil,
+        byMinute: [Int]? = nil,
+        byHour: [Int]? = nil,
+        byDay: [Day]? = nil,
+        byDayOfMonth: [Int]? = nil,
+        byWeekOfYear: [Int]? = nil,
+        byMonth: [Int]? = nil,
+        bySetPos: [Int]? = nil,
+        startOfWorkweek: DayOfWeek? = nil
+    ) {
+        self.frequency = frequency
+        self.interval = interval
+        self.until = until
+        self.count = count
+        self.bySecond = bySecond
+        self.byMinute = byMinute
+        self.byHour = byHour
+        self.byDay = byDay
+        self.byDayOfMonth = byDayOfMonth
+        self.byWeekOfYear = byWeekOfYear
+        self.byMonth = byMonth
+        self.bySetPos = bySetPos
+        self.startOfWorkweek = startOfWorkweek
+    }
 }

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -1,0 +1,60 @@
+/// This value type is used to identify properties that contain
+/// a recurrence rule specification.
+///
+/// See https://tools.ietf.org/html/rfc5545#section-3.3.10
+public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
+    /// The frequency of the recurrence.
+    public var frequency: Frequency
+    /// At which interval the recurrence repeats (in terms of the frequency).
+    /// E.g. 1 means every hour for an hourly rule, ...
+    /// The default value is 1.
+    public var interval: Int?
+
+    /// The end date/time. Must have the same 'ignoreTime'-value as dtstart.
+    public var until: ICalendarDate? {
+        willSet { count = nil }
+    }
+    /// The number of recurrences.
+    public var count: Int? {
+        willSet { until = nil }
+    }
+
+    private var properties: [String: ICalendarEncodable?] {
+        [
+            "FREQ": frequency,
+            "INTERVAL": interval,
+            "UNTIL": until,
+            "COUNT": count
+        ]
+    }
+
+    public var iCalendarEncoded: String {
+        properties.compactMap { (key, value) in value.map { "\(key)=\($0.iCalendarEncoded)" } }.joined(separator: ";")
+    }
+
+    public enum Frequency: String, ICalendarEncodable {
+        case secondly = "SECONDLY"
+        case minutely = "MINUTELY"
+        case hourly = "HOURLY"
+        case daily = "DAILY"
+        case weekly = "WEEKLY"
+        case monthly = "MONTHLY"
+        case yearly = "YEARLY"
+
+        public var iCalendarEncoded: String { rawValue }
+    }
+
+    public enum Weekday: String, ICalendarEncodable {
+        case monday = "MO"
+        case tuesday = "TU"
+        case wednesday = "WE"
+        case thursday = "TH"
+        case friday = "FR"
+        case saturday = "SA"
+        case sunday = "SU"
+
+        public var iCalendarEncoded: String { rawValue }
+    }
+
+    // TODO: Initializer
+}

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -19,6 +19,38 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         willSet { until = nil }
     }
 
+    /// At which seconds of the minute it should occur.
+    /// Must be between 0 and 60 (inclusive).
+    public var bySeconds: [Int]? {
+        didSet { assert(bySeconds?.allSatisfy { (0...60).contains($0) } ?? true, "by-second rules must be between 0 and 60 (inclusive): \(bySeconds ?? [])") }
+    }
+    /// At which minutes of the hour it should occur.
+    /// Must be between 0 and 60 (exclusive).
+    public var byMinutes: [Int]? {
+        didSet { assert(byMinutes?.allSatisfy { (0..<60).contains($0) } ?? true, "by-hour rules must be between 0 and 60 (exclusive): \(byMinutes ?? [])") }
+    }
+    /// At which hours of the day it should occur.
+    /// Must be between 0 and 24 (exclusive).
+    public var byHours: [Int]? {
+        didSet { assert(byHours?.allSatisfy { (0..<24).contains($0) } ?? true, "by-hour rules must be between 0 and 24 (exclusive): \(byHours ?? [])") }
+    }
+    /// At which days (of the week/year) it should occur.
+    public var byDay: [SignedDay]?
+    /// At which days of the month it should occur.
+    public var byDaysOfMonth: [SignedDayOfMonth]?
+    /// At which days of the year it should occur.
+    public var byDaysOfYear: [SignedDayOfYear]?
+    /// At which weeks of the year it should occur.
+    public var byWeekOfYear: [SignedWeekOfYear]?
+    /// At which months it should occur.
+    /// Must be between 1 and 12 (inclusive).
+    public var byMonthOfYear: [Int]? {
+        didSet { assert(byMonthOfYear?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonthOfYear ?? [])") }
+    }
+    /// The day on which the workweek starts.
+    /// Monday by default.
+    public var startOfWorkweek: DayOfWeek?
+
     private var properties: [String: ICalendarEncodable?] {
         [
             "FREQ": frequency,
@@ -44,7 +76,7 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         public var iCalendarEncoded: String { rawValue }
     }
 
-    public enum Weekday: String, ICalendarEncodable {
+    public enum DayOfWeek: String, ICalendarEncodable {
         case monday = "MO"
         case tuesday = "TU"
         case wednesday = "WE"
@@ -54,6 +86,61 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         case sunday = "SU"
 
         public var iCalendarEncoded: String { rawValue }
+    }
+
+    public struct SignedDay: ICalendarEncodable {
+        /// The week of the day. May be negative.
+        public let weekOfYear: Int?
+        /// The day of the week.
+        public let dayOfWeek: DayOfWeek
+
+        public var iCalendarEncoded: String { "\(weekOfYear.map { "\($0.signum() > 0 ? "" : "-")\(abs($0))" } ?? "")\(dayOfWeek.iCalendarEncoded)" }
+
+        public init(weekOfYear: Int? = nil, dayOfWeek: DayOfWeek) {
+            self.weekOfYear = weekOfYear
+            self.dayOfWeek = dayOfWeek
+
+            assert(weekOfYear.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(weekOfYear.map(String.init) ?? "?") is not between 1 and 53 (inclusive)")
+        }
+    }
+
+    public struct SignedDayOfMonth: ICalendarEncodable {
+        /// The day of the month. May be negative.
+        public let dayOfMonth: Int
+
+        public var iCalendarEncoded: String { "\(dayOfMonth.signum() > 0 ? "" : "-")\(abs(dayOfMonth))" }
+
+        public init(dayOfMonth: Int) {
+            self.dayOfMonth = dayOfMonth
+
+            assert((1...31).contains(abs(dayOfMonth)), "Day-of-month \(dayOfMonth) is not between 1 and 31 (inclusive)")
+        }
+    }
+
+    public struct SignedDayOfYear: ICalendarEncodable {
+        /// The day of the year. May be negative.
+        public let dayOfYear: Int
+
+        public var iCalendarEncoded: String { "\(dayOfYear.signum() > 0 ? "" : "-")\(abs(dayOfYear))" }
+
+        public init(dayOfYear: Int) {
+            self.dayOfYear = dayOfYear
+
+            assert((1...366).contains(abs(dayOfYear)), "Day-of-year \(dayOfYear) is not between 1 and 366 (inclusive)")
+        }
+    }
+
+    public struct SignedWeekOfYear: ICalendarEncodable {
+        /// The week of the year. May be negative.
+        public let weekOfYear: Int
+
+        public var iCalendarEncoded: String { "\(weekOfYear.signum() > 0 ? "" : "-")\(abs(weekOfYear))" }
+
+        public init(weekOfYear: Int) {
+            self.weekOfYear = weekOfYear
+
+            assert((1...53).contains(abs(weekOfYear)), "Week-of-year \(weekOfYear) is not between 1 and 53 (inclusive)")
+        }
     }
 
     // TODO: Initializer

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -35,27 +35,36 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         didSet { assert(byHours?.allSatisfy { (0..<24).contains($0) } ?? true, "by-hour rules must be between 0 and 24 (exclusive): \(byHours ?? [])") }
     }
     /// At which days (of the week/year) it should occur.
-    public var byDays: [SignedDay]?
-    /// At which days of the month it should occur.
-    public var byDaysOfMonth: [SignedDayOfMonth]?
-    /// At which days of the year it should occur.
-    public var byDaysOfYear: [SignedDayOfYear]?
-    /// At which weeks of the year it should occur.
-    public var byWeeksOfYear: [SignedWeekOfYear]?
+    public var byDays: [Day]?
+    /// At which days of the month it should occur. Specifies a COMMA-separated
+    /// list of days of the month. Valid values are 1 to 31 or -31 to -1.
+    public var byDaysOfMonth: [Int]? {
+        didSet { assert(byDaysOfYear?.allSatisfy { (1...31).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 31 or -31 and -1: \(byDaysOfMonth ?? [])") }
+    }
+    /// At which days of the year it should occur. Specifies a list of days
+    /// of the year.  Valid values are 1 to 366 or -366 to -1.
+    public var byDaysOfYear: [Int]? {
+        didSet { assert(byWeeksOfYear?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(byDaysOfYear ?? [])") }
+    }
+    /// At which weeks of the year it should occur. Specificies a list of
+    /// ordinals specifying weeks of the year. Valid values are 1 to 53 or -53 to
+    /// -1.
+    public var byWeeksOfYear: [Int]? {
+        didSet { assert(byWeeksOfYear?.allSatisfy { (1...53).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 53 or -53 and -1: \(byWeeksOfYear ?? [])") }
+    }
     /// At which months it should occur.
     /// Must be between 1 and 12 (inclusive).
     public var byMonths: [Int]? {
         didSet { assert(byMonths?.allSatisfy { (1...12).contains($0) } ?? true, "by-month-of-year rules must be between 1 and 12: \(byMonths ?? [])") }
     }
-    /// Specifies a list of values
-    /// that corresponds to the nth occurrence within the set of
-    /// recurrence instances specified by the rule. By-set-pos operates on
-    /// a set of recurrence instances in one interval of the recurrence
-    /// rule.  For example, in a weekly rule, the interval would be one
+    /// Specifies a list of values that corresponds to the nth occurrence within
+    /// the set of recurrence instances specified by the rule. By-set-pos
+    /// operates on a set of recurrence instances in one interval of the
+    /// recurrence rule. For example, in a weekly rule, the interval would be one
     /// week A set of recurrence instances starts at the beginning of the
-    /// interval defined by the frequency rule part.  Valid values are 1 to 366
-    /// or -366 to -1.  It MUST only be used in conjunction with another
-    /// by-xxx rule part.
+    /// interval defined by the frequency rule part. Valid values are 1 to 366 or
+    /// -366 to -1. It MUST only be used in conjunction with another by-xxx rule
+    /// part.
     public var bySetPos: [Int]? {
         didSet { assert(bySetPos?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(bySetPos ?? [])") }
     }
@@ -111,58 +120,19 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         public var iCalendarEncoded: String { rawValue }
     }
 
-    public struct SignedDay: ICalendarEncodable {
+    public struct Day: ICalendarEncodable {
         /// The week of the day. May be negative.
         public let weekOfYear: Int?
         /// The day of the week.
         public let dayOfWeek: DayOfWeek
 
-        public var iCalendarEncoded: String { "\(weekOfYear.map { "\($0.signum() > 0 ? "" : "-")\(abs($0))" } ?? "")\(dayOfWeek.iCalendarEncoded)" }
+        public var iCalendarEncoded: String { "\(weekOfYear.map(String.init) ?? "")\(dayOfWeek.iCalendarEncoded)" }
 
         public init(weekOfYear: Int? = nil, dayOfWeek: DayOfWeek) {
             self.weekOfYear = weekOfYear
             self.dayOfWeek = dayOfWeek
 
-            assert(weekOfYear.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(weekOfYear.map(String.init) ?? "?") is not between 1 and 53 (inclusive)")
-        }
-    }
-
-    public struct SignedDayOfMonth: ICalendarEncodable {
-        /// The day of the month. May be negative.
-        public let dayOfMonth: Int
-
-        public var iCalendarEncoded: String { "\(dayOfMonth.signum() > 0 ? "" : "-")\(abs(dayOfMonth))" }
-
-        public init(dayOfMonth: Int) {
-            self.dayOfMonth = dayOfMonth
-
-            assert((1...31).contains(abs(dayOfMonth)), "Day-of-month \(dayOfMonth) is not between 1 and 31 (inclusive)")
-        }
-    }
-
-    public struct SignedDayOfYear: ICalendarEncodable {
-        /// The day of the year. May be negative.
-        public let dayOfYear: Int
-
-        public var iCalendarEncoded: String { "\(dayOfYear.signum() > 0 ? "" : "-")\(abs(dayOfYear))" }
-
-        public init(dayOfYear: Int) {
-            self.dayOfYear = dayOfYear
-
-            assert((1...366).contains(abs(dayOfYear)), "Day-of-year \(dayOfYear) is not between 1 and 366 (inclusive)")
-        }
-    }
-
-    public struct SignedWeekOfYear: ICalendarEncodable {
-        /// The week of the year. May be negative.
-        public let weekOfYear: Int
-
-        public var iCalendarEncoded: String { "\(weekOfYear.signum() > 0 ? "" : "-")\(abs(weekOfYear))" }
-
-        public init(weekOfYear: Int) {
-            self.weekOfYear = weekOfYear
-
-            assert((1...53).contains(abs(weekOfYear)), "Week-of-year \(weekOfYear) is not between 1 and 53 (inclusive)")
+            assert(weekOfYear.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(weekOfYear.map(String.init) ?? "?") is not between 1 and 53 or -53 and -1 (each inclusive)")
         }
     }
 

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -120,22 +120,30 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
     }
 
     public struct Day: ICalendarEncodable {
-        /// The week of the day. May be negative.
-        public let weekOfYear: Int?
+        /// The week. May be negative.
+        public let week: Int?
         /// The day of the week.
         public let dayOfWeek: DayOfWeek
 
-        public var iCalendarEncoded: String { "\(weekOfYear.map(String.init) ?? "")\(dayOfWeek.iCalendarEncoded)" }
+        public var iCalendarEncoded: String { "\(week.map(String.init) ?? "")\(dayOfWeek.iCalendarEncoded)" }
 
-        public init(weekOfYear: Int? = nil, dayOfWeek: DayOfWeek) {
-            self.weekOfYear = weekOfYear
+        public init(week: Int? = nil, dayOfWeek: DayOfWeek) {
+            self.week = week
             self.dayOfWeek = dayOfWeek
 
-            assert(weekOfYear.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(weekOfYear.map(String.init) ?? "?") is not between 1 and 53 or -53 and -1 (each inclusive)")
+            assert(week.map { (1...53).contains(abs($0)) } ?? true, "Week-of-year \(week.map(String.init) ?? "?") is not between 1 and 53 or -53 and -1 (each inclusive)")
         }
 
-        public static func dayOfWeek(_ dayOfWeek: DayOfWeek) -> Self {
+        public static func every(_ dayOfWeek: DayOfWeek) -> Self {
             Self(dayOfWeek: dayOfWeek)
+        }
+
+        public static func first(_ dayOfWeek: DayOfWeek) -> Self {
+            Self(week: 1, dayOfWeek: dayOfWeek)
+        }
+
+        public static func last(_ dayOfWeek: DayOfWeek) -> Self {
+            Self(week: -1, dayOfWeek: dayOfWeek)
         }
     }
 

--- a/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
+++ b/Sources/ICalendar/structures/ICalendarRecurrenceRule.swift
@@ -39,12 +39,12 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
     /// At which days of the month it should occur. Specifies a COMMA-separated
     /// list of days of the month. Valid values are 1 to 31 or -31 to -1.
     public var byDayOfMonth: [Int]? {
-        didSet { assert(byDaysOfYear?.allSatisfy { (1...31).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 31 or -31 and -1: \(byDayOfMonth ?? [])") }
+        didSet { assert(byDayOfMonth?.allSatisfy { (1...31).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 31 or -31 and -1: \(byDayOfMonth ?? [])") }
     }
     /// At which days of the year it should occur. Specifies a list of days
     /// of the year.  Valid values are 1 to 366 or -366 to -1.
-    public var byDaysOfYear: [Int]? {
-        didSet { assert(byWeekOfYear?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(byDaysOfYear ?? [])") }
+    public var byDayOfYear: [Int]? {
+        didSet { assert(byDayOfYear?.allSatisfy { (1...366).contains(abs($0)) } ?? true, "by-set-pos rules must be between 1 and 366 or -366 and -1: \(byDayOfYear ?? [])") }
     }
     /// At which weeks of the year it should occur. Specificies a list of
     /// ordinals specifying weeks of the year. Valid values are 1 to 53 or -53 to
@@ -83,7 +83,7 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
             ("BYHOUR", byHour),
             ("BYDAY", byDay),
             ("BYMONTHDAY", byDayOfMonth),
-            ("BYYEARDAY", byDaysOfYear),
+            ("BYYEARDAY", byDayOfYear),
             ("BYWEEKNO", byWeekOfYear),
             ("BYMONTH", byMonth),
             ("BYSETPOS", bySetPos),
@@ -157,6 +157,7 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         byHour: [Int]? = nil,
         byDay: [Day]? = nil,
         byDayOfMonth: [Int]? = nil,
+        byDayOfYear: [Int]? = nil,
         byWeekOfYear: [Int]? = nil,
         byMonth: [Int]? = nil,
         bySetPos: [Int]? = nil,
@@ -171,6 +172,7 @@ public struct ICalendarRecurrenceRule: ICalendarPropertyEncodable {
         self.byHour = byHour
         self.byDay = byDay
         self.byDayOfMonth = byDayOfMonth
+        self.byDayOfYear = byDayOfYear
         self.byWeekOfYear = byWeekOfYear
         self.byMonth = byMonth
         self.bySetPos = bySetPos

--- a/Tests/ICalendarTests/XCTestManifests.swift
+++ b/Tests/ICalendarTests/XCTestManifests.swift
@@ -5,7 +5,8 @@ public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ICalendarTests.allTests),
         testCase(StringUtilitiesTests.allTests),
-        testCase(ICalendarRecurrenceRuleTests.allTests)
+        testCase(ICalendarRecurrenceRuleTests.allTests),
+        testCase(ICalendarDurationTests.allTests)
     ]
 }
 #endif

--- a/Tests/ICalendarTests/XCTestManifests.swift
+++ b/Tests/ICalendarTests/XCTestManifests.swift
@@ -4,7 +4,8 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ICalendarTests.allTests),
-        testCase(StringUtilitiesTests.allTests)
+        testCase(StringUtilitiesTests.allTests),
+        testCase(ICalendarRecurrenceRuleTests.allTests)
     ]
 }
 #endif

--- a/Tests/ICalendarTests/components/ICalendarTests.swift
+++ b/Tests/ICalendarTests/components/ICalendarTests.swift
@@ -39,9 +39,9 @@ final class ICalendarTests: XCTestCase {
             uid: uid,
             created: dates[1].date,
             description: description,
-            dtstart: ICalendarDate(date: dates[2].date),
+            dtstart: .dateTime(dates[2].date),
             lastModified: dates[3].date,
-            dtend: ICalendarDate(date: dates[4].date, ignoreTime: true)
+            dtend: .dateOnly(dates[4].date)
         ))
 
         XCTAssertEqual(cal.iCalendarEncoded, [

--- a/Tests/ICalendarTests/structures/ICalendarDurationTests.swift
+++ b/Tests/ICalendarTests/structures/ICalendarDurationTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import Foundation
+@testable import ICalendar
+
+final class ICalendarDurationTests: XCTestCase {
+    static var allTests = [
+        ("testDurations", testDurations)
+    ]
+
+    func testDurations() throws {
+        assert(duration: .zero, hasTotalSeconds: 0)
+        assert(duration: .seconds(10), hasTotalSeconds: 10)
+        assert(duration: .minutes(2), hasTotalSeconds: 120)
+        assert(duration: .hours(1), hasTotalSeconds: 3600)
+        assert(duration: .days(1), hasTotalSeconds: 24 * 3600)
+        assert(duration: .weeks(1) + .days(1), hasTotalSeconds: 8 * 24 * 3600)
+
+        let x: ICalendarDuration = .weeks(1) + .days(1) + .hours(25) + .seconds(63)
+
+        XCTAssertEqual(x.parts.weeks, 1)
+        XCTAssertEqual(x.parts.days, 2)
+        XCTAssertEqual(x.parts.hours, 1)
+        XCTAssertEqual(x.parts.minutes, 1)
+        XCTAssertEqual(x.parts.seconds, 3)
+    }
+
+    private func assert(duration: ICalendarDuration, hasTotalSeconds totalSeconds: Int64, line: UInt = #line) {
+        XCTAssertEqual(duration.totalSeconds, totalSeconds, line: line)
+    }
+}

--- a/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
+++ b/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import Foundation
+@testable import ICalendar
+
+final class ICalendarRecurrenceRuleTests: XCTestCase {
+    static var allTests = [
+        ("testRecurrenceRules", testRecurrenceRules)
+    ]
+    private var calendar = Calendar(identifier: .gregorian)
+
+    override func setUp() {
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    func testRecurrenceRules() throws {
+        // Examples are (partly) taken from https://tools.ietf.org/html/rfc5545#section-3.8.5.3
+
+        // Daily for 10 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .daily, count: 10).iCalendarEncoded, "FREQ=DAILY;COUNT=10")
+        // Daily until December 24, 1997
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .daily, until: .dateTime(date(1997, 12, 24))).iCalendarEncoded, "FREQ=DAILY;UNTIL=19971224T000000Z")
+        // Every other day, forever
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .daily, interval: 2).iCalendarEncoded, "FREQ=DAILY;INTERVAL=2")
+        // Every 10 days, 5 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .daily, interval: 10, count: 5).iCalendarEncoded, "FREQ=DAILY;INTERVAL=10;COUNT=5")
+        // Every day in January, until January 31, 2000
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, until: .dateOnly(date(2000, 1, 31))).iCalendarEncoded, "FREQ=YEARLY;UNTIL=20000131")
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 0, minute: 0, second: 0))!
+    }
+}

--- a/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
+++ b/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
@@ -26,7 +26,11 @@ final class ICalendarRecurrenceRuleTests: XCTestCase {
         // Every day in January, until January 31, 2000
         XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, until: .dateOnly(date(2000, 1, 31))).iCalendarEncoded, "FREQ=YEARLY;UNTIL=20000131")
         // Weekly on tuesday and thursday for 5 weeks
-        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .weekly, count: 10, byDay: [.dayOfWeek(.tuesday), .dayOfWeek(.thursday)]).iCalendarEncoded, "FREQ=WEEKLY;COUNT=10;BYDAY=TU,TH")
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .weekly, count: 10, byDay: [.every(.tuesday), .every(.thursday)]).iCalendarEncoded, "FREQ=WEEKLY;COUNT=10;BYDAY=TU,TH")
+        // Each other week on monday, wednesday and friday until December 24, 1997
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .weekly, interval: 2, until: .dateTime(date(1997, 12, 24)), byDay: [.every(.monday), .every(.wednesday), .every(.friday)], startOfWorkweek: .monday).iCalendarEncoded, "FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;BYDAY=MO,WE,FR;WKST=MO")
+        // Every other month of the first and last sunday of the month for 10 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .monthly, interval: 2, count: 10, byDay: [.first(.sunday), .last(.sunday)]).iCalendarEncoded, "FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU")
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {

--- a/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
+++ b/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
@@ -25,6 +25,8 @@ final class ICalendarRecurrenceRuleTests: XCTestCase {
         XCTAssertEqual(ICalendarRecurrenceRule(frequency: .daily, interval: 10, count: 5).iCalendarEncoded, "FREQ=DAILY;INTERVAL=10;COUNT=5")
         // Every day in January, until January 31, 2000
         XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, until: .dateOnly(date(2000, 1, 31))).iCalendarEncoded, "FREQ=YEARLY;UNTIL=20000131")
+        // Weekly on tuesday and thursday for 5 weeks
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .weekly, count: 10, byDay: [.dayOfWeek(.tuesday), .dayOfWeek(.thursday)]).iCalendarEncoded, "FREQ=WEEKLY;COUNT=10;BYDAY=TU,TH")
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {

--- a/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
+++ b/Tests/ICalendarTests/structures/ICalendarRecurrenceRuleTests.swift
@@ -31,6 +31,16 @@ final class ICalendarRecurrenceRuleTests: XCTestCase {
         XCTAssertEqual(ICalendarRecurrenceRule(frequency: .weekly, interval: 2, until: .dateTime(date(1997, 12, 24)), byDay: [.every(.monday), .every(.wednesday), .every(.friday)], startOfWorkweek: .monday).iCalendarEncoded, "FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;BYDAY=MO,WE,FR;WKST=MO")
         // Every other month of the first and last sunday of the month for 10 occurrences
         XCTAssertEqual(ICalendarRecurrenceRule(frequency: .monthly, interval: 2, count: 10, byDay: [.first(.sunday), .last(.sunday)]).iCalendarEncoded, "FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU")
+        // Monthly on the third-to-the-last day of the month, forever
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .monthly, byDayOfMonth: [-3]).iCalendarEncoded, "FREQ=MONTHLY;BYMONTHDAY=-3")
+        // Monthly on the 2nd and 15th of the month for 10 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .monthly, byDayOfMonth: [2, 15]).iCalendarEncoded, "FREQ=MONTHLY;BYMONTHDAY=2,15")
+        // Yearly in June and July for 10 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, byMonth: [6, 7]).iCalendarEncoded, "FREQ=YEARLY;BYMONTH=6,7")
+        // Every third year on the 1st, 100th and 200th day for 10 occurrences
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, interval: 3, byDayOfYear: [1, 100, 200]).iCalendarEncoded, "FREQ=YEARLY;INTERVAL=3;BYYEARDAY=1,100,200")
+        // Every 20th monday of the year, forever
+        XCTAssertEqual(ICalendarRecurrenceRule(frequency: .yearly, byDay: [.init(week: 20, dayOfWeek: .monday)]).iCalendarEncoded, "FREQ=YEARLY;BYDAY=20MO")
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {


### PR DESCRIPTION
### Fixes #6 

Add a structure `ICalendarRecurrenceRule` that makes it easy to define custom recurrences, e.g. like this:

```swift
// Every day in January, until January 31, 2000
ICalendarRecurrenceRule(frequency: .yearly, until: .dateOnly(date(2000, 1, 31)))
// Weekly on tuesday and thursday for 5 weeks
ICalendarRecurrenceRule(frequency: .weekly, count: 10, byDay: [.every(.tuesday), .every(.thursday)])
```